### PR TITLE
Rewrite `setup.py` to allow compiling C libraries without `autotools`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 
 .test-linux: &test-linux
   os: linux
+  arch: amd64
   dist: bionic
   stage: Test (Linux)
   language: python
@@ -27,6 +28,7 @@ env:
 .test-osx: &test-osx
   os: osx
   osx_image: xcode7.3
+  arch: amd64
   stage: Test (OSX)
   language: generic
   cache:
@@ -40,6 +42,15 @@ env:
   before_cache: ci/travis/osx/before_cache.sh
   before_deploy: ci/travis/osx/before_deploy.sh
   after_success: ci/travis/osx/after_success.sh
+
+.test-powerpc: &test-powerpc
+  os: linux
+  arch: ppc64le
+  state: Test (Linux PowerPC)
+  language: python
+  cache: pip
+  install: pip install -r ci/requirements.txt
+  script: python setup.py build_ext --inplace --debug test
 
 jobs:
   include:
@@ -73,6 +84,9 @@ jobs:
     - env: PYTHON=python3.8
       name: "Python: 3.8"
       <<: *test-osx
+    # Linux (PowerPC)
+    - python: 3.8
+      <<: *test-powerpc
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,15 +43,6 @@ env:
   before_deploy: ci/travis/osx/before_deploy.sh
   after_success: ci/travis/osx/after_success.sh
 
-.test-powerpc: &test-powerpc
-  os: linux
-  arch: ppc64le
-  state: Test (Linux PowerPC)
-  language: python
-  cache: pip
-  install: pip install -r ci/requirements.txt
-  script: python setup.py build_ext --inplace --debug test
-
 jobs:
   include:
     # Linux
@@ -84,9 +75,6 @@ jobs:
     - env: PYTHON=python3.8
       name: "Python: 3.8"
       <<: *test-osx
-    # Linux (PowerPC)
-    - python: 3.8
-      <<: *test-powerpc
 
 deploy:
   provider: script

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,10 +9,16 @@ prune             tests
 
 recursive-include vendor                      *
 recursive-exclude vendor/hmmer                *.ai
-#prune             vendor/easel/documentation
-#prune             vendor/easel/miniapps 
-#prune             vendor/easel/demotic
-#prune             vendor/hmmer/documentation
-#prune             vendor/hmmer/contrib
-#prune             vendor/hmmer/testsuite
-#prune             vendor/hmmer/tutorial
+recursive-exclude vendor                      *.pl
+prune             vendor/easel/demotic
+prune             vendor/easel/documentation
+prune             vendor/easel/esl_msa_testfiles
+prune             vendor/easel/miniapps
+prune             vendor/easel/testsuite
+prune             vendor/hmmer/autobuild
+prune             vendor/hmmer/documentation
+prune             vendor/hmmer/contrib
+prune             vendor/hmmer/profmark
+prune             vendor/hmmer/testsuite
+prune             vendor/hmmer/test-speed
+prune             vendor/hmmer/tutorial

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ $ pip install pyhmmer
 
 ## 📖 Documentation
 
-A complete [API reference] can be found in the [online documentation], or
-directly from the command line using [`pydoc`](https://docs.python.org/3/library/pydoc.html):
+A complete [API reference](https://pyhmmer.readthedocs.io/en/stable/api/) can
+be found in the [online documentation]((https://pyhmmer.readthedocs.io/), or
+directly from the command line using 
+[`pydoc`](https://docs.python.org/3/library/pydoc.html):
 ```console
 $ pydoc pyhmmer.easel
 $ pydoc pyhmmer.plan7

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 *[Cython](https://cython.org/) bindings and Python interface to [HMMER3](http://hmmer.org/).*
 
 [![TravisCI](https://img.shields.io/travis/com/althonos/pyhmmer/master.svg?logo=travis&maxAge=600&style=flat-square)](https://travis-ci.com/althonos/pyhmmer/branches)
-[![AppVeyor](https://img.shields.io/appveyor/build/althonos/pyhmmer/master.svg?logo=appveyor&maxAge=600&style=flat-square)](https://ci.appveyor.com/project/althonos/pyhmmer/history)
 [![Coverage](https://img.shields.io/codecov/c/gh/althonos/pyhmmer?style=flat-square&maxAge=3600)](https://codecov.io/gh/althonos/pyhmmer/)
 [![PyPI](https://img.shields.io/pypi/v/pyhmmer.svg?style=flat-square&maxAge=3600)](https://pypi.org/project/pyhmmer)
 [![Wheel](https://img.shields.io/pypi/wheel/pyhmmer.svg?style=flat-square&maxAge=3600)](https://pypi.org/project/pyhmmer/#files)
@@ -12,10 +11,11 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square&maxAge=2678400)](https://choosealicense.com/licenses/mit/)
 [![Source](https://img.shields.io/badge/source-GitHub-303030.svg?maxAge=2678400&style=flat-square)](https://github.com/althonos/pyhmmer/)
 [![GitHub issues](https://img.shields.io/github/issues/althonos/pyhmmer.svg?style=flat-square&maxAge=600)](https://github.com/althonos/pyhmmer/issues)
-![Docs](https://img.shields.io/readthedocs/pyhmmer/latest?style=flat-square&maxAge=600)
+[![Docs](https://img.shields.io/readthedocs/pyhmmer/latest?style=flat-square&maxAge=600)](https://pyhmmer.readthedocs.io)
 [![Changelog](https://img.shields.io/badge/keep%20a-changelog-8A0707.svg?maxAge=2678400&style=flat-square)](https://github.com/althonos/pyhmmer/blob/master/CHANGELOG.md)
+[![Downloads](https://img.shields.io/badge/dynamic/json?style=flat-square&color=303f9f&maxAge=86400&label=downloads&query=%24.total_downloads&url=https%3A%2F%2Fapi.pepy.tech%2Fapi%2Fprojects%2Fpyhmmer)](https://pepy.tech/project/pyhmmer)
 
-<!-- [![Downloads](https://img.shields.io/badge/dynamic/json?style=flat-square&color=303f9f&maxAge=86400&label=downloads&query=%24.total_downloads&url=https%3A%2F%2Fapi.pepy.tech%2Fapi%2Fprojects%2Fpyhmmer)](https://pepy.tech/project/pyhmmer) -->
+<!-- [![AppVeyor](https://img.shields.io/appveyor/build/althonos/pyhmmer/master.svg?logo=appveyor&maxAge=600&style=flat-square)](https://ci.appveyor.com/project/althonos/pyhmmer/history) -->
 <!-- [![Bioconda](https://img.shields.io/conda/vn/bioconda/pyhmmer?style=flat-square&maxAge=3600)](https://anaconda.org/bioconda/pyhmmer) -->
 
 
@@ -51,30 +51,40 @@ HMMER internals, which has the following advantages over CLI wrappers
   and HMMs in disk storage is typically not slower than directly using the
   `hmmsearch` binary (see the [Benchmarks section](#%EF%B8%8F-benchmarks)).
 
+*This library is still a work-in-progress, and in a very experimental stage,
+but it should already pack enough features to run simple biological analyses.*
+
 
 ## 🔧 Installing
 
 ``pyhmmer`` can be installed from [PyPI](https://pypi.org/project/pyhmmer/),
-which hosts some pre-built CPython wheels for x86-64 Unix and Windows platforms,
+which hosts some pre-built CPython wheels for x86-64 Linux and OSX,
 as well as the code required to compile from source with Cython:
 ```console
 $ pip install pyhmmer
 ```
 
+Compilation for UNIX PowerPC is not tested in CI, but should work out of the
+box. Other architectures (e.g. Arm) and OSes (e.g. Windows) are not
+supported by HMMER.
+
+
 ## 📖 Documentation
 
 A complete [API reference](https://pyhmmer.readthedocs.io/en/stable/api/) can
-be found in the [online documentation]((https://pyhmmer.readthedocs.io/), or
-directly from the command line using 
+be found in the [online documentation](https://pyhmmer.readthedocs.io/), or
+directly from the command line using
 [`pydoc`](https://docs.python.org/3/library/pydoc.html):
 ```console
 $ pydoc pyhmmer.easel
 $ pydoc pyhmmer.plan7
 ```
 
+
 ## 💡 Example
 
-Use `pyhmmer` to run `hmmsearch`, and display domain hits:
+Use `pyhmmer` to run `hmmsearch`, and display alignments for hits with
+domains longer than 30 letters :
 
 ```python
 import pyhmmer
@@ -103,6 +113,7 @@ for hit in hits:
             print(domain.alignment.target_sequence)
 ```
 
+
 ## ⏱️ Benchmarks
 
 Benchmarks were run on a i7-8550U CPU running at 1.80GHz, using a FASTA file
@@ -116,7 +127,7 @@ were set to use 8 threads, and were run 20 times.
 | `python -m hmmer.hmmsearch` | 40.128   | 946    | 37.706  | 42.457  |
 
 
-## 📜 License
+## ⚖️ License
 
 This library is provided under the [MIT License](https://choosealicense.com/licenses/mit/).
 The HMMER3 and Easel code is available under the BSD 3-clause license. See

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,14 +8,11 @@ pyHMMER |Stars|
 *Cython bindings and Python interface to* `HMMER3 <http://hmmer.org/>`_.
 
 
-|TravisCI| |AppVeyor| |Coverage| |PyPI| |Wheel| |Versions| |Implementations| |License| |Source| |Issues| |Docs| |Changelog|
+|TravisCI| |Coverage| |PyPI| |Wheel| |Versions| |Implementations| |License| |Source| |Issues| |Docs| |Changelog| |Downloads|
 
 
 .. |TravisCI| image:: https://img.shields.io/travis/althonos/pyhmmer/master.svg?&maxAge=600&style=flat-square
    :target: https://travis-ci.org/althonos/pyhmmer/branches
-
-.. |AppVeyor| image:: https://img.shields.io/appveyor/build/althonos/pyhmmer/master.svg?logo=appveyor&maxAge=600&style=flat-square
-   :target: https://ci.appveyor.com/project/althonos/pyhmmer/history
 
 .. |Coverage| image:: https://img.shields.io/codecov/c/gh/althonos/pyhmmer?style=flat-square&maxAge=3600
    :target: https://www.codecov.com/gh/althonos/pyhmmer/
@@ -47,6 +44,8 @@ pyHMMER |Stars|
 .. |Changelog| image:: https://img.shields.io/badge/keep%20a-changelog-8A0707.svg?maxAge=2678400&style=flat-square
    :target: https://github.com/althonos/pyhmmer/blob/master/CHANGELOG.md
 
+.. |Downloads| image:: https://img.shields.io/badge/dynamic/json?style=flat-square&color=303f9f&maxAge=86400&label=downloads&query=%24.total_downloads&url=https%3A%2F%2Fapi.pepy.tech%2Fapi%2Fprojects%2Fpyhmmer
+   :target: https://pepy.tech/project/pyhmmer
 
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,12 +3,10 @@ Installation
 
 .. note::
 
-    Most platforms, such as Linux x86-64, OSX and Windows x86-64 provide
+    Common UNIX architectures such as Linux x86-64 and OSX and x86-64 provide
     precompiled wheels, but other less frequent platforms will require building
     the wheel yourself. Building ``pyhmmer`` involves compiling HMMER3 and Easel
-    from source, which requires a C compiler to be available on the machine,
-    as well as GNU `make <https://www.gnu.org/s/make/>` and
-    `autotools <https://www.gnu.org/s/automake>`.
+    from source, which requires a C compiler to be available on the machine.
 
 
 PyPi
@@ -60,5 +58,5 @@ project dependencies yourself:
 
 	$ git clone https://github.com/althonos/pyhmmer
 	$ cd pyhmmer
-	$ python setup.py build_clib build_ext
+	$ python setup.py build
 	# python setup.py install

--- a/include/libhmmer/impl_sse/p7_oprofile.pxd
+++ b/include/libhmmer/impl_sse/p7_oprofile.pxd
@@ -1,7 +1,11 @@
 from libc.stdint cimport uint8_t, int16_t
+from libc.stdio cimport FILE
 from posix.types cimport off_t
 
 from libeasel.alphabet cimport ESL_ALPHABET
+from libeasel.random cimport ESL_RANDOMNESS
+from libhmmer.p7_bg cimport P7_BG
+from libhmmer.p7_hmm cimport P7_HMM
 from libhmmer.p7_profile cimport P7_PROFILE
 
 
@@ -26,114 +30,114 @@ cdef extern from "emmintrin.h":
 
 cdef extern from "impl_sse/impl_sse.h" nogil:
 
-  DEF p7O_NXSTATES = 4
-  cdef enum p7o_xstates_e:
-      p7O_E  = 0
-      p7O_N  = 1
-      p7O_J  = 2
-      p7O_C  = 3
+    DEF p7O_NXSTATES = 4
+    cdef enum p7o_xstates_e:
+        p7O_E  = 0
+        p7O_N  = 1
+        p7O_J  = 2
+        p7O_C  = 3
 
-  DEF p7O_NXTRANS = 2
-  cdef enum p7o_xtransitions_e:
-      p7O_MOVE = 0
-      p7O_LOOP = 1
+    DEF p7O_NXTRANS = 2
+    cdef enum p7o_xtransitions_e:
+        p7O_MOVE = 0
+        p7O_LOOP = 1
 
-  DEF p7O_NTRANS = 8
-  cdef enum p7o_tsc_e:
-      p7O_BM = 0
-      p7O_MM = 1
-      p7O_IM = 2
-      p7O_DM = 3
-      p7O_MD = 4
-      p7O_MI = 5
-      p7O_II = 6
-      p7O_DD = 7
-
-
-  ctypedef p7_oprofile_s P7_OPROFILE
-  cdef struct p7_oprofile_s:
-      __m128i** rbv
-      __m128i** sbv
-      uint8_t tbm_b
-      uint8_t tec_b
-      uint8_t tjb_b
-      float scale_b
-      uint8_t base_b
-      uint8_t bias_b
-
-      __m128i** rwv
-      __m128i*  twv
-      int16_t[p7O_NXSTATES][p7O_NXTRANS] xw
-      float scale_w
-      int16_t base_w
-      int16_t ddbound_w
-      float ncj_roundoff
-
-      __m128** rfv
-      __m128* tfv
-      int16_t[p7O_NXSTATES][p7O_NXTRANS] xf
-
-      __m128i  *rbv_mem
-      __m128i  *sbv_mem
-      __m128i  *rwv_mem
-      __m128i  *twv_mem
-      __m128   *tfv_mem
-      __m128   *rfv_mem
-
-      off_t[p7_NOFFSETS]  offs
-      off_t  roff
-      off_t  eoff
-
-      char* name
-      char* acc
-      char* desc
-      char* rf
-      char* mm
-      char* cs
-      char* consensus
-      float[p7_NEVPARAM] evparam
-      float[p7_NCUTOFFS] cutoff
-      float[p7_MAXABET] compo
-      const ESL_ALPHABET* abc
-
-      int L
-      int M
-      int max_length
-      int allocM
-      int allocQ4
-      int allocQ8
-      int allocQ16
-      int mode
-      float nj
-
-      int clone
+    DEF p7O_NTRANS = 8
+    cdef enum p7o_tsc_e:
+        p7O_BM = 0
+        p7O_MM = 1
+        p7O_IM = 2
+        p7O_DM = 3
+        p7O_MD = 4
+        p7O_MI = 5
+        p7O_II = 6
+        p7O_DD = 7
 
 
-  P7_OPROFILE *p7_oprofile_Create(int M, const ESL_ALPHABET *abc);
-  # int          p7_oprofile_IsLocal(const P7_OPROFILE *om);
-  void         p7_oprofile_Destroy(P7_OPROFILE *om);
-  # size_t       p7_oprofile_Sizeof(P7_OPROFILE *om);
-  # P7_OPROFILE *p7_oprofile_Copy(P7_OPROFILE *om);
-  # P7_OPROFILE *p7_oprofile_Clone(const P7_OPROFILE *om);
-  # int          p7_oprofile_UpdateFwdEmissionScores(P7_OPROFILE *om, P7_BG *bg, float *fwd_emissions, float *sc_arr);
-  # int          p7_oprofile_UpdateVitEmissionScores(P7_OPROFILE *om, P7_BG *bg, float *fwd_emissions, float *sc_arr);
-  # int          p7_oprofile_UpdateMSVEmissionScores(P7_OPROFILE *om, P7_BG *bg, float *fwd_emissions, float *sc_arr);
+    ctypedef p7_oprofile_s P7_OPROFILE
+    cdef struct p7_oprofile_s:
+        __m128i** rbv
+        __m128i** sbv
+        uint8_t tbm_b
+        uint8_t tec_b
+        uint8_t tjb_b
+        float scale_b
+        uint8_t base_b
+        uint8_t bias_b
 
-  int          p7_oprofile_Convert(const P7_PROFILE *gm, P7_OPROFILE *om);
-  int          p7_oprofile_ReconfigLength    (P7_OPROFILE *om, int L);
-  int          p7_oprofile_ReconfigMSVLength (P7_OPROFILE *om, int L);
-  int          p7_oprofile_ReconfigRestLength(P7_OPROFILE *om, int L);
-  int          p7_oprofile_ReconfigMultihit  (P7_OPROFILE *om, int L);
-  int          p7_oprofile_ReconfigUnihit    (P7_OPROFILE *om, int L);
+        __m128i** rwv
+        __m128i*  twv
+        int16_t[p7O_NXSTATES][p7O_NXTRANS] xw
+        float scale_w
+        int16_t base_w
+        int16_t ddbound_w
+        float ncj_roundoff
 
-  # int          p7_oprofile_Dump(FILE *fp, const P7_OPROFILE *om);
-  # int          p7_oprofile_Sample(ESL_RANDOMNESS *r, const ESL_ALPHABET *abc, const P7_BG *bg, int M, int L,
-  #                P7_HMM **opt_hmm, P7_PROFILE **opt_gm, P7_OPROFILE **ret_om);
-  # int          p7_oprofile_Compare(const P7_OPROFILE *om1, const P7_OPROFILE *om2, float tol, char *errmsg);
-  # int          p7_profile_SameAsMF(const P7_OPROFILE *om, P7_PROFILE *gm);
-  # int          p7_profile_SameAsVF(const P7_OPROFILE *om, P7_PROFILE *gm);
-  #
-  # int          p7_oprofile_GetFwdTransitionArray(const P7_OPROFILE *om, int type, float *arr );
-  # int          p7_oprofile_GetSSVEmissionScoreArray(const P7_OPROFILE *om, uint8_t *arr );
-  # int          p7_oprofile_GetFwdEmissionScoreArray(const P7_OPROFILE *om, float *arr );
-  # int          p7_oprofile_GetFwdEmissionArray(const P7_OPROFILE *om, P7_BG *bg, float *arr );
+        __m128** rfv
+        __m128* tfv
+        int16_t[p7O_NXSTATES][p7O_NXTRANS] xf
+
+        __m128i  *rbv_mem
+        __m128i  *sbv_mem
+        __m128i  *rwv_mem
+        __m128i  *twv_mem
+        __m128   *tfv_mem
+        __m128   *rfv_mem
+
+        off_t[p7_NOFFSETS]  offs
+        off_t  roff
+        off_t  eoff
+
+        char* name
+        char* acc
+        char* desc
+        char* rf
+        char* mm
+        char* cs
+        char* consensus
+        float[p7_NEVPARAM] evparam
+        float[p7_NCUTOFFS] cutoff
+        float[p7_MAXABET] compo
+        const ESL_ALPHABET* abc
+
+        int L
+        int M
+        int max_length
+        int allocM
+        int allocQ4
+        int allocQ8
+        int allocQ16
+        int mode
+        float nj
+
+        int clone
+
+
+    P7_OPROFILE *p7_oprofile_Create(int M, const ESL_ALPHABET *abc)
+    int          p7_oprofile_IsLocal(const P7_OPROFILE *om)
+    void         p7_oprofile_Destroy(P7_OPROFILE *om)
+    size_t       p7_oprofile_Sizeof(P7_OPROFILE *om)
+    P7_OPROFILE *p7_oprofile_Copy(P7_OPROFILE *om)
+    P7_OPROFILE *p7_oprofile_Clone(const P7_OPROFILE *om)
+    int          p7_oprofile_UpdateFwdEmissionScores(P7_OPROFILE *om, P7_BG *bg, float *fwd_emissions, float *sc_arr)
+    int          p7_oprofile_UpdateVitEmissionScores(P7_OPROFILE *om, P7_BG *bg, float *fwd_emissions, float *sc_arr)
+    int          p7_oprofile_UpdateMSVEmissionScores(P7_OPROFILE *om, P7_BG *bg, float *fwd_emissions, float *sc_arr)
+
+    int          p7_oprofile_Convert(const P7_PROFILE *gm, P7_OPROFILE *om)
+    int          p7_oprofile_ReconfigLength    (P7_OPROFILE *om, int L)
+    int          p7_oprofile_ReconfigMSVLength (P7_OPROFILE *om, int L)
+    int          p7_oprofile_ReconfigRestLength(P7_OPROFILE *om, int L)
+    int          p7_oprofile_ReconfigMultihit  (P7_OPROFILE *om, int L)
+    int          p7_oprofile_ReconfigUnihit    (P7_OPROFILE *om, int L)
+
+    int          p7_oprofile_Dump(FILE *fp, const P7_OPROFILE *om)
+    int          p7_oprofile_Sample(ESL_RANDOMNESS *r, const ESL_ALPHABET *abc, const P7_BG *bg, int M, int L,
+                   P7_HMM **opt_hmm, P7_PROFILE **opt_gm, P7_OPROFILE **ret_om)
+    int          p7_oprofile_Compare(const P7_OPROFILE *om1, const P7_OPROFILE *om2, float tol, char *errmsg)
+    int          p7_profile_SameAsMF(const P7_OPROFILE *om, P7_PROFILE *gm)
+    int          p7_profile_SameAsVF(const P7_OPROFILE *om, P7_PROFILE *gm)
+
+    int          p7_oprofile_GetFwdTransitionArray(const P7_OPROFILE *om, int type, float *arr )
+    int          p7_oprofile_GetSSVEmissionScoreArray(const P7_OPROFILE *om, uint8_t *arr )
+    int          p7_oprofile_GetFwdEmissionScoreArray(const P7_OPROFILE *om, float *arr )
+    int          p7_oprofile_GetFwdEmissionArray(const P7_OPROFILE *om, P7_BG *bg, float *arr )

--- a/include/libhmmer/impl_vmx/__init__.pxd
+++ b/include/libhmmer/impl_vmx/__init__.pxd
@@ -1,0 +1,2 @@
+cdef extern from "impl_vmx/impl_vmx.h" nogil:
+    cdef void impl_Init()

--- a/include/libhmmer/impl_vmx/p7_omx.pxd
+++ b/include/libhmmer/impl_vmx/p7_omx.pxd
@@ -1,0 +1,5 @@
+cdef extern from "impl_vmx/impl_vmx.h" nogil:
+
+    ctypedef p7_omx_s P7_OMX
+    cdef struct p7_omx_s:
+        pass

--- a/include/libhmmer/impl_vmx/p7_oprofile.pxd
+++ b/include/libhmmer/impl_vmx/p7_oprofile.pxd
@@ -1,5 +1,136 @@
+from libc.stdint cimport uint8_t, int16_t
+from libc.stdio cimport FILE
+from posix.types cimport off_t
+
+from libeasel.alphabet cimport ESL_ALPHABET
+from libeasel.random cimport ESL_RANDOMNESS
+from libhmmer.p7_bg cimport P7_BG
+from libhmmer.p7_hmm cimport P7_HMM
+from libhmmer.p7_profile cimport P7_PROFILE
+
+
+cdef extern from "p7_config.h" nogil:
+    DEF p7_MAXABET = 20
+
+
+cdef extern from "hmmer.h" nogil:
+    DEF p7_NEVPARAM = 6
+    DEF p7_NCUTOFFS = 6
+    DEF p7_NOFFSETS = 3
+
+
 cdef extern from "impl_vmx/impl_vmx.h" nogil:
+
+    DEF p7O_NXSTATES = 4
+    cdef enum p7o_xstates_e:
+        p7O_E = 0
+        p7O_N = 1
+        p7O_J = 2
+        p7O_C = 3
+
+    DEF p7O_NXTRANS = 2
+    cdef enum p7o_xtransitions_e:
+        p7O_MOVE = 0
+        p7O_LOOP = 1
+
+    DEF p7O_NTRANS = 8
+    cdef enum p7o_tsc_e:
+        p7O_BM   = 0
+        p7O_MM   = 1
+        p7O_IM   = 2
+        p7O_DM   = 3
+        p7O_MD   = 4
+        p7O_MI   = 5
+        p7O_II   = 6
+        p7O_DD   = 7
 
     ctypedef p7_oprofile_s P7_OPROFILE
     cdef struct p7_oprofile_s:
-        pass
+        # vector unsigned char** rbv
+        uint8_t   tbm_b
+        uint8_t   tec_b
+        uint8_t   tjb_b
+        float     scale_b
+        uint8_t   base_b
+        uint8_t   bias_b
+
+        # vector signed short **rwv
+        # vector signed short  *twv
+        int16_t[p7O_NXSTATES][p7O_NXTRANS]   xw
+        float     scale_w
+        int16_t   base_w
+        int16_t   ddbound_w
+        float     ncj_roundoff
+
+        # vector float **rfv
+        # vector float  *tfv
+        float[p7O_NXSTATES][p7O_NXTRANS]    xf
+
+        # vector unsigned char  *rbv_mem
+        # vector signed short   *rwv_mem
+        # vector signed short   *twv_mem
+        # vector float          *tfv_mem
+        # vector float          *rfv_mem
+
+        off_t[p7_NOFFSETS]  offs
+        off_t  roff
+        off_t  eoff
+
+        char  *name
+        char  *acc
+        char  *desc
+        char  *rf
+        char  *mm
+        char  *cs
+        char  *consensus
+        float[p7_NEVPARAM]  evparam
+        float[p7_NCUTOFFS]  cutoff
+        float[p7_MAXABET]  compo
+        const ESL_ALPHABET *abc
+
+        int L
+        int M
+        int max_length
+        int allocM
+        int allocQ4
+        int allocQ8
+        int allocQ16
+        int mode
+        float nj
+
+        int clone
+
+    ctypedef struct P7_OM_BLOCK:
+        int count
+        int listSize
+        P7_OPROFILE** list
+
+
+    P7_OPROFILE *p7_oprofile_Create(int M, const ESL_ALPHABET *abc)
+    int          p7_oprofile_IsLocal(const P7_OPROFILE *om)
+    void         p7_oprofile_Destroy(P7_OPROFILE *om)
+    size_t       p7_oprofile_Sizeof(P7_OPROFILE *om)
+    P7_OPROFILE *p7_oprofile_Copy(P7_OPROFILE *om)
+    P7_OPROFILE *p7_oprofile_Clone(const P7_OPROFILE *om)
+    int          p7_oprofile_UpdateFwdEmissionScores(P7_OPROFILE *om, P7_BG *bg, float *fwd_emissions, float *sc_arr)
+    int          p7_oprofile_UpdateVitEmissionScores(P7_OPROFILE *om, P7_BG *bg, float *fwd_emissions, float *sc_arr)
+    int          p7_oprofile_UpdateMSVEmissionScores(P7_OPROFILE *om, P7_BG *bg, float *fwd_emissions, float *sc_arr)
+
+    int          p7_oprofile_Convert(const P7_PROFILE *gm, P7_OPROFILE *om)
+    int          p7_oprofile_ReconfigLength    (P7_OPROFILE *om, int L)
+    int          p7_oprofile_ReconfigMSVLength (P7_OPROFILE *om, int L)
+    int          p7_oprofile_ReconfigRestLength(P7_OPROFILE *om, int L)
+    int          p7_oprofile_ReconfigMultihit  (P7_OPROFILE *om, int L)
+    int          p7_oprofile_ReconfigUnihit    (P7_OPROFILE *om, int L)
+
+    int          p7_oprofile_Dump(FILE *fp, const P7_OPROFILE *om)
+    int          p7_oprofile_Sample(ESL_RANDOMNESS *r, const ESL_ALPHABET *abc, const P7_BG *bg, int M, int L,
+    				       P7_HMM **opt_hmm, P7_PROFILE **opt_gm, P7_OPROFILE **ret_om)
+    int          p7_oprofile_Compare(const P7_OPROFILE *om1, const P7_OPROFILE *om2, float tol, char *errmsg)
+    int          p7_profile_SameAsMF(const P7_OPROFILE *om, P7_PROFILE *gm)
+    int          p7_profile_SameAsVF(const P7_OPROFILE *om, P7_PROFILE *gm)
+
+    int          p7_oprofile_GetFwdTransitionArray(const P7_OPROFILE *om, int type, float *arr )
+    int          p7_oprofile_GetSSVEmissionScoreArray(const P7_OPROFILE *om, uint8_t *arr )
+    int          p7_oprofile_GetFwdEmissionScoreArray(const P7_OPROFILE *om, float *arr )
+    int          p7_oprofile_GetFwdEmissionArray(const P7_OPROFILE *om, P7_BG *bg, float *arr )

--- a/include/libhmmer/impl_vmx/p7_oprofile.pxd
+++ b/include/libhmmer/impl_vmx/p7_oprofile.pxd
@@ -1,0 +1,5 @@
+cdef extern from "impl_vmx/impl_vmx.h" nogil:
+
+    ctypedef p7_oprofile_s P7_OPROFILE
+    cdef struct p7_oprofile_s:
+        pass

--- a/include/libhmmer/p7_alidisplay.pxd
+++ b/include/libhmmer/p7_alidisplay.pxd
@@ -7,9 +7,9 @@ from libeasel.sq cimport ESL_SQ
 from libhmmer.p7_trace cimport P7_TRACE
 from libhmmer.p7_pipeline cimport P7_PIPELINE
 
-IF UNAME_MACHINE.startswith("ppc") and not UNAME_MACHINE.endswith("le"):
+IF HMMER_IMPL == "VMX":
     from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
-ELIF UNAME_MACHINE.startswith(("x86", "i386", "i686")):
+ELIF HMMER_IMPL == "SSE":
     from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 
 

--- a/include/libhmmer/p7_alidisplay.pxd
+++ b/include/libhmmer/p7_alidisplay.pxd
@@ -7,9 +7,9 @@ from libeasel.sq cimport ESL_SQ
 from libhmmer.p7_trace cimport P7_TRACE
 from libhmmer.p7_pipeline cimport P7_PIPELINE
 
-IF UNAME_MACHINE.startswith("ppc"):
+IF UNAME_MACHINE.startswith("ppc") and not UNAME_MACHINE.endswith("le"):
     from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
-ELIF UNAME_MACHINE.startswith(("x86", "amd")):
+ELIF UNAME_MACHINE.startswith(("x86", "i386", "i686")):
     from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 
 

--- a/include/libhmmer/p7_alidisplay.pxd
+++ b/include/libhmmer/p7_alidisplay.pxd
@@ -4,9 +4,13 @@ from libc.stdio cimport FILE
 from libeasel.alphabet cimport ESL_ALPHABET
 from libeasel.random cimport ESL_RANDOMNESS
 from libeasel.sq cimport ESL_SQ
-from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 from libhmmer.p7_trace cimport P7_TRACE
 from libhmmer.p7_pipeline cimport P7_PIPELINE
+
+IF UNAME_MACHINE.startswith("ppc"):
+    from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
+ELIF UNAME_MACHINE.startswith(("x86", "amd")):
+    from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 
 
 cdef extern from "hmmer.h" nogil:

--- a/include/libhmmer/p7_domaindef.pxd
+++ b/include/libhmmer/p7_domaindef.pxd
@@ -6,10 +6,10 @@ from libhmmer.p7_domain cimport P7_DOMAIN
 from libhmmer.p7_spensemble cimport P7_SPENSEMBLE
 from libhmmer.p7_trace cimport P7_TRACE
 
-IF UNAME_MACHINE.startswith("ppc"):
+IF UNAME_MACHINE.startswith("ppc") and not UNAME_MACHINE.endswith("le"):
     from libhmmer.impl_vmx.p7_omx cimport P7_OMX
     from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
-ELIF UNAME_MACHINE.startswith(("x86", "amd")):
+ELIF UNAME_MACHINE.startswith(("x86", "i386", "i686")):
     from libhmmer.impl_sse.p7_omx cimport P7_OMX
     from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 

--- a/include/libhmmer/p7_domaindef.pxd
+++ b/include/libhmmer/p7_domaindef.pxd
@@ -2,11 +2,16 @@ from libc.stdio cimport FILE
 
 from libeasel.random cimport ESL_RANDOMNESS
 from libeasel.sq cimport ESL_SQ
-from libhmmer.impl_sse.p7_omx cimport P7_OMX
-from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 from libhmmer.p7_domain cimport P7_DOMAIN
 from libhmmer.p7_spensemble cimport P7_SPENSEMBLE
 from libhmmer.p7_trace cimport P7_TRACE
+
+IF UNAME_MACHINE.startswith("ppc"):
+    from libhmmer.impl_vmx.p7_omx cimport P7_OMX
+    from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
+ELIF UNAME_MACHINE.startswith(("x86", "amd")):
+    from libhmmer.impl_sse.p7_omx cimport P7_OMX
+    from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 
 
 cdef extern from "hmmer.h" nogil:

--- a/include/libhmmer/p7_domaindef.pxd
+++ b/include/libhmmer/p7_domaindef.pxd
@@ -6,10 +6,10 @@ from libhmmer.p7_domain cimport P7_DOMAIN
 from libhmmer.p7_spensemble cimport P7_SPENSEMBLE
 from libhmmer.p7_trace cimport P7_TRACE
 
-IF UNAME_MACHINE.startswith("ppc") and not UNAME_MACHINE.endswith("le"):
+IF HMMER_IMPL == "VMX":
     from libhmmer.impl_vmx.p7_omx cimport P7_OMX
     from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
-ELIF UNAME_MACHINE.startswith(("x86", "i386", "i686")):
+ELIF HMMER_IMPL == "SSE":
     from libhmmer.impl_sse.p7_omx cimport P7_OMX
     from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 

--- a/include/libhmmer/p7_pipeline.pxd
+++ b/include/libhmmer/p7_pipeline.pxd
@@ -8,10 +8,10 @@ from libhmmer.p7_domaindef cimport P7_DOMAINDEF
 from libhmmer.p7_tophits cimport P7_TOPHITS
 from libhmmer.p7_hmmfile cimport P7_HMMFILE
 
-IF UNAME_MACHINE.startswith("ppc"):
+IF UNAME_MACHINE.startswith("ppc") and not UNAME_MACHINE.endswith("le"):
     from libhmmer.impl_vmx.p7_omx cimport P7_OMX
     from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
-ELIF UNAME_MACHINE.startswith(("x86", "amd")):
+ELIF UNAME_MACHINE.startswith(("x86", "i386", "i686")):
     from libhmmer.impl_sse.p7_omx cimport P7_OMX
     from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 

--- a/include/libhmmer/p7_pipeline.pxd
+++ b/include/libhmmer/p7_pipeline.pxd
@@ -8,10 +8,10 @@ from libhmmer.p7_domaindef cimport P7_DOMAINDEF
 from libhmmer.p7_tophits cimport P7_TOPHITS
 from libhmmer.p7_hmmfile cimport P7_HMMFILE
 
-IF UNAME_MACHINE.startswith("ppc") and not UNAME_MACHINE.endswith("le"):
+IF HMMER_IMPL == "VMX":
     from libhmmer.impl_vmx.p7_omx cimport P7_OMX
     from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
-ELIF UNAME_MACHINE.startswith(("x86", "i386", "i686")):
+ELIF HMMER_IMPL == "SSE":
     from libhmmer.impl_sse.p7_omx cimport P7_OMX
     from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 

--- a/include/libhmmer/p7_pipeline.pxd
+++ b/include/libhmmer/p7_pipeline.pxd
@@ -3,12 +3,17 @@ from libc.stdint cimport uint64_t
 from libeasel.sq cimport ESL_SQ
 from libeasel.getopts cimport ESL_GETOPTS
 from libeasel.random cimport ESL_RANDOMNESS
-from libhmmer.impl_sse.p7_omx cimport P7_OMX
-from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 from libhmmer.p7_bg cimport P7_BG
 from libhmmer.p7_domaindef cimport P7_DOMAINDEF
 from libhmmer.p7_tophits cimport P7_TOPHITS
 from libhmmer.p7_hmmfile cimport P7_HMMFILE
+
+IF UNAME_MACHINE.startswith("ppc"):
+    from libhmmer.impl_vmx.p7_omx cimport P7_OMX
+    from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
+ELIF UNAME_MACHINE.startswith(("x86", "amd")):
+    from libhmmer.impl_sse.p7_omx cimport P7_OMX
+    from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 
 
 cdef extern from "easel.h" nogil:

--- a/pyhmmer/easel.pyx
+++ b/pyhmmer/easel.pyx
@@ -4,7 +4,7 @@
 
 Easel is a library developed by the `Eddy/Rivas Lab <http://eddylab.org/>`_
 to facilitate the development of biological software in C. It is used by
-`HMMER <http://hmmer.org/>_` and `Infernal <http://eddylab.org/infernal/>`_.
+`HMMER <http://hmmer.org/>`_ and `Infernal <http://eddylab.org/infernal/>`_.
 
 """
 

--- a/pyhmmer/plan7.pyx
+++ b/pyhmmer/plan7.pyx
@@ -35,11 +35,11 @@ from libhmmer.p7_alidisplay cimport P7_ALIDISPLAY
 from libhmmer.logsum cimport p7_FLogsumInit
 from libhmmer.p7_pipeline cimport P7_PIPELINE, p7_pipemodes_e
 
-IF UNAME_MACHINE.startswith("ppc"):
+IF UNAME_MACHINE.startswith("ppc") and not UNAME_MACHINE.endswith("le"):
     from libhmmer.impl_vmx cimport p7_oprofile
     from libhmmer.impl_vmx cimport impl_Init
     from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
-ELIF UNAME_MACHINE.startswith(("x86", "amd")):
+ELIF UNAME_MACHINE.startswith(("x86", "i386", "i686")):
     from libhmmer.impl_sse cimport p7_oprofile
     from libhmmer.impl_sse cimport impl_Init
     from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE

--- a/pyhmmer/plan7.pyx
+++ b/pyhmmer/plan7.pyx
@@ -34,9 +34,14 @@ from libeasel.sq cimport ESL_SQ
 from libhmmer cimport p7_LOCAL
 from libhmmer.p7_alidisplay cimport P7_ALIDISPLAY
 from libhmmer.logsum cimport p7_FLogsumInit
-from libhmmer.impl_sse cimport impl_Init
-from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 from libhmmer.p7_pipeline cimport P7_PIPELINE, p7_pipemodes_e
+
+IF PLATFORM_MACHINE.startswith("ppc"):
+    from libhmmer.impl_vmx cimport impl_Init
+    from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
+ELIF PLATFORM_MACHINE.startswith(("x86", "amd")):
+    from libhmmer.impl_sse cimport impl_Init
+    from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 
 from .easel cimport Alphabet, Sequence
 

--- a/pyhmmer/plan7.pyx
+++ b/pyhmmer/plan7.pyx
@@ -35,11 +35,11 @@ from libhmmer.p7_alidisplay cimport P7_ALIDISPLAY
 from libhmmer.logsum cimport p7_FLogsumInit
 from libhmmer.p7_pipeline cimport P7_PIPELINE, p7_pipemodes_e
 
-IF UNAME_MACHINE.startswith("ppc") and not UNAME_MACHINE.endswith("le"):
+IF HMMER_IMPL == "VMX":
     from libhmmer.impl_vmx cimport p7_oprofile
     from libhmmer.impl_vmx cimport impl_Init
     from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
-ELIF UNAME_MACHINE.startswith(("x86", "i386", "i686")):
+ELIF HMMER_IMPL == "SSE":
     from libhmmer.impl_sse cimport p7_oprofile
     from libhmmer.impl_sse cimport impl_Init
     from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE

--- a/pyhmmer/plan7.pyx
+++ b/pyhmmer/plan7.pyx
@@ -19,7 +19,6 @@ cimport libeasel
 cimport libeasel.sq
 cimport libeasel.alphabet
 cimport libeasel.getopts
-cimport libhmmer.impl_sse.p7_oprofile
 cimport libhmmer.modelconfig
 cimport libhmmer.p7_hmm
 cimport libhmmer.p7_bg
@@ -36,10 +35,12 @@ from libhmmer.p7_alidisplay cimport P7_ALIDISPLAY
 from libhmmer.logsum cimport p7_FLogsumInit
 from libhmmer.p7_pipeline cimport P7_PIPELINE, p7_pipemodes_e
 
-IF PLATFORM_MACHINE.startswith("ppc"):
+IF UNAME_MACHINE.startswith("ppc"):
+    from libhmmer.impl_vmx cimport p7_oprofile
     from libhmmer.impl_vmx cimport impl_Init
     from libhmmer.impl_vmx.p7_oprofile cimport P7_OPROFILE
-ELIF PLATFORM_MACHINE.startswith(("x86", "amd")):
+ELIF UNAME_MACHINE.startswith(("x86", "amd")):
+    from libhmmer.impl_sse cimport p7_oprofile
     from libhmmer.impl_sse cimport impl_Init
     from libhmmer.impl_sse.p7_oprofile cimport P7_OPROFILE
 
@@ -481,8 +482,8 @@ cdef class Pipeline:
                 raise RuntimeError()
 
             # build the optimized model from the HMM
-            om = libhmmer.impl_sse.p7_oprofile.p7_oprofile_Create(hm.M, abc)
-            if libhmmer.impl_sse.p7_oprofile.p7_oprofile_Convert(gm, om):
+            om = p7_oprofile.p7_oprofile_Create(hm.M, abc)
+            if p7_oprofile.p7_oprofile_Convert(gm, om):
                 raise RuntimeError()
 
             # configure the pipeline for the current HMM
@@ -504,7 +505,7 @@ cdef class Pipeline:
                     raise RuntimeError()
                 if libhmmer.p7_bg.p7_bg_SetLength(bg, sq.n):
                     raise RuntimeError()
-                if libhmmer.impl_sse.p7_oprofile.p7_oprofile_ReconfigLength(om, sq.n):
+                if p7_oprofile.p7_oprofile_ReconfigLength(om, sq.n):
                     raise RuntimeError()
 
                 # run the pipeline on the sequence
@@ -522,7 +523,7 @@ cdef class Pipeline:
 
             # deallocate the profile and optimized model
             libhmmer.p7_profile.p7_profile_Destroy(gm)
-            libhmmer.impl_sse.p7_oprofile.p7_oprofile_Destroy(om)
+            p7_oprofile.p7_oprofile_Destroy(om)
 
         #
         return hits

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+# https://gist.github.com/althonos/6914b896789d3f2078d1e6237642c35c
+
+# --- Setuptools metadata ---------------------------------------------------
+
 [metadata]
 name = pyhmmer
 version = attr: pyhmmer.__version__
@@ -32,6 +36,7 @@ project_urls =
 [options]
 zip_safe = false
 packages = pyhmmer
+python_requires = >= 3.5
 test_suite = tests
 include_package_data = true
 setup_requires =
@@ -40,6 +45,94 @@ setup_requires =
 
 [options.package_data]
 pyhmmer = py.typed, *.pyi
+
+
+# --- C libraries configuration ---------------------------------------------
+
+[configure.divsufsort]
+filename = divsufsort.h
+copy = vendor/hmmer/libdivsufsort/divsufsort.h.in
+
+[configure.easel]
+filename = esl_config.h
+constants =
+    EASEL_DATE      = "Jul 2020"
+    EASEL_COPYRIGHT = "Copyright (C) 2020 Howard Hughes Medical Institute"
+    EASEL_LICENSE   = "Freely distributed under the BSD open source license."
+    EASEL_VERSION   = "0.47"
+    EASEL_URL       = "http://bioeasel.org/"
+headers =
+    endian.h
+    inttypes.h
+    stdint.h
+    unistd.h
+    strings.h
+    netinet/in.h
+    sys/types.h
+    sys/param.h
+    sys/sysctl.h
+functions =
+    aligned_alloc
+    erfc
+    getpid
+    _mm_malloc
+    popen
+    posix_memalign
+    strcasecmp
+    strsep
+    sysconf
+    sysctl
+    times
+    fseeko
+
+[configure.hmmer]
+filename = p7_config.h
+constants =
+    HMMER_VERSION     = "3.3.1"
+    HMMER_DATE        = "Jul 2020"
+    HMMER_LICENSE     = "Freely distributed under the BSD open source license."
+    HMMER_URL         = "http://hmmer.org/"
+    HMMER_COPYRIGHT   = "Copyright (C) 2020 Howard Hughes Medical Institute."
+    p7_RAMLIMIT       = 32
+    p7_NCPU           = "2"
+    p7_ALILENGTH      = 50
+    p7_ETARGET_AMINO  = 0.59
+    p7_ETARGET_DNA    = 0.62
+    p7_ETARGET_OTHER  = 1.0
+    p7_SEQDBENV       = "BLASTDB"
+    p7_HMMDBENV       = "PFAMDB"
+    p7_MAXABET        = 20
+    p7_MAXCODE        = 29
+    p7_MAX_SC_TXTLEN  = 11
+    p7_MAXDCHLET      = 20
+headers =
+    endian.h
+    inttypes.h
+    stdint.h
+    unistd.h
+    sys/types.h
+    netinet/in.h
+    sys/param.h
+    sys/sysctl.h
+functions =
+    mkstemp
+    popen
+    putenv
+    strcasecmp
+    strsep
+    times
+    getpid
+    sysctl
+    sysconf
+    getcwd
+    chmod
+    stat
+    fstat
+    erfc
+    
+
+
+# --- Python tools configuration --------------------------------------------
 
 [coverage:run]
 plugins = Cython.Coverage

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ import setuptools
 from distutils import log
 from distutils.command.clean import clean as _clean
 from distutils.errors import CompileError
-from distutils.spawn import spawn
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.build_clib import build_clib as _build_clib
 from setuptools.command.sdist import sdist as _sdist

--- a/setup.py
+++ b/setup.py
@@ -364,7 +364,8 @@ hmmer_sources = [
 
 if platform.machine().startswith('ppc'):
     hmmer_sources.extend(glob.glob(os.path.join("vendor", "hmmer", "src", "impl_vmx", "*.c")))
-    platform_defines = [("eslENABLE_VMX", 1)]
+    hmmer_sources.remove(os.path.join("vendor", "hmmer", "src", "impl_vmx", "vitscore.c"))
+    platform_define_macros = [("eslENABLE_VMX", 1)]
     platform_compile_args = ["-maltivec"]
 else:
     # just assume we are running on x86-64, but should be checked to be sure

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,6 @@ class build_ext(_build_ext):
 
         # use debug directives with Cython if building in debug mode
         cython_args = {"include_path": ["include"], "compiler_directives": {}}
-        if machine is not None:
-            cython_args["compile_time_env"] = { "PLATFORM_MACHINE": machine }
         if self.force:
             cython_args["force"] = True
         if self.debug:

--- a/setup.py
+++ b/setup.py
@@ -379,18 +379,21 @@ hmmer_sources = [
     ]
 ]
 
-if platform.machine().startswith('ppc'):
+# HMMER3 is only supported on x86 CPUs with SSE, and big endian PowerPC
+# (see https://github.com/EddyRivasLab/hmmer/issues/142)
+machine = platform.machine()
+if machine.startswith('ppc') and not machine.endswith('le'):
     hmmer_sources.extend(glob.glob(os.path.join("vendor", "hmmer", "src", "impl_vmx", "*.c")))
     hmmer_sources.remove(os.path.join("vendor", "hmmer", "src", "impl_vmx", "vitscore.c"))
     platform_define_macros = [("eslENABLE_VMX", 1)]
     platform_compile_args = ["-maltivec"]
-else:
-    # just assume we are running on x86-64, but should be checked to be sure
-    # (platform.machine doesn't work on Windows though)
+elif machine.startswith(("x86", "i386", "i686")):
     hmmer_sources.extend(glob.glob(os.path.join("vendor", "hmmer", "src", "impl_sse", "*.c")))
     hmmer_sources.remove(os.path.join("vendor", "hmmer", "src", "impl_sse", "vitscore.c"))
     platform_define_macros = [("eslENABLE_SSE", 1)]
     platform_compile_args = ["-msse3"]
+else:
+    log.warn('pyHMMER is not supported on CPU architecture: "{}"'.format(machine))
 
 libraries = [
     Library(


### PR DESCRIPTION
Code was updated to use the `distutils.ccompiler` API, so that it's not needed to run `autotools` when building `libhmmer` and `libeasel`. Platform-specific code for PowerPC/VMX implementation was also added. 