### PR TITLE
Save sequence name after translation

### DIFF
--- a/pyhmmer/easel.pyx
+++ b/pyhmmer/easel.pyx
@@ -5883,11 +5883,11 @@ cdef class DigitalSequenceBlock(SequenceBlock):
             # create new object
             protein = DigitalSequence(
                 genetic_code.amino_alphabet,
-                name=self._refs[i].name,
-                description=self._refs[i].desc,
-                accession=self._refs[i].acc,
-                source=self._refs[i].source,
-                taxonomy_id=self._refs[i].tax_id
+                name=self._storage[i].name,
+                description=self._storage[i].description,
+                accession=self._storage[i].accession,
+                source=self._storage[i].source,
+                taxonomy_id=self._storage[i].taxonomy_id
             )
 
             proteins._append(protein)

--- a/pyhmmer/easel.pyx
+++ b/pyhmmer/easel.pyx
@@ -4906,6 +4906,8 @@ cdef class TextSequence(Sequence):
 
         if status == libeasel.eslOK:
             assert libeasel.sq.esl_sq_IsDigital(new._sq)
+            new.taxonomy_id = self._sq.tax_id
+
             return new
         elif status == libeasel.eslEINVAL:
             raise ValueError(f"Cannot digitize sequence with alphabet {alphabet}: invalid chars in sequence")
@@ -5154,12 +5156,15 @@ cdef class DigitalSequence(Sequence):
 
         with nogil:
             new._sq = libeasel.sq.esl_sq_Create()
+
             if new._sq == NULL:
                 raise AllocationError("ESL_SQ", sizeof(ESL_SQ))
 
             status = libeasel.sq.esl_sq_Copy(self._sq, new._sq)
             if status != libeasel.eslOK:
                 raise UnexpectedError(status, "esl_sq_Copy")
+
+            new._sq.tax_id = self._sq.tax_id
 
         assert libeasel.sq.esl_sq_IsText(new._sq)
         return new
@@ -5647,6 +5652,7 @@ cdef class TextSequenceBlock(SequenceBlock):
         with nogil:
             for i in range(self._length):
                 libeasel.sq.esl_sq_Copy(self._refs[i], block._refs[i])
+                block._refs[i].tax_id = self._refs[i].tax_id
 
         return block
 
@@ -5821,6 +5827,7 @@ cdef class DigitalSequenceBlock(SequenceBlock):
         with nogil:
             for i in range(self._length):
                 libeasel.sq.esl_sq_Copy(self._refs[i], block._refs[i])
+                block._refs[i].tax_id = self._refs[i].tax_id
 
         return block
 

--- a/pyhmmer/easel.pyx
+++ b/pyhmmer/easel.pyx
@@ -4861,8 +4861,7 @@ cdef class TextSequence(Sequence):
             self.description = description
         if source is not None:
             self.source = source
-        if taxonomy_id is not None:
-            self.taxonomy_id = taxonomy_id
+        self.taxonomy_id = taxonomy_id
 
         assert libeasel.sq.esl_sq_IsText(self._sq)
         assert self._sq.name != NULL
@@ -4906,8 +4905,7 @@ cdef class TextSequence(Sequence):
 
         if status == libeasel.eslOK:
             assert libeasel.sq.esl_sq_IsDigital(new._sq)
-            new.taxonomy_id = self._sq.tax_id
-
+            new.taxonomy_id = self.taxonomy_id
             return new
         elif status == libeasel.eslEINVAL:
             raise ValueError(f"Cannot digitize sequence with alphabet {alphabet}: invalid chars in sequence")
@@ -5076,8 +5074,7 @@ cdef class DigitalSequence(Sequence):
             self.description = description
         if source is not None:
             self.source = source
-        if taxonomy_id is not None:
-            self.taxonomy_id = taxonomy_id
+        self.taxonomy_id = taxonomy_id
 
         assert libeasel.sq.esl_sq_IsDigital(self._sq)
         assert self._sq.name != NULL

--- a/pyhmmer/easel.pyx
+++ b/pyhmmer/easel.pyx
@@ -5202,20 +5202,25 @@ cdef class DigitalSequence(Sequence):
         assert self._sq != NULL
         assert self.alphabet is not None
 
+        cdef DigitalSequence protein
         cdef int64_t         ntlen   = len(self)
         cdef int64_t         aalen   = ntlen // 3
-        cdef DigitalSequence protein = DigitalSequence(genetic_code.amino_alphabet,
-                                                       name=self.name,
-                                                       description=self.description,
-                                                       accession=self.accession,
-                                                       source=self.source,
-                                                       taxonomy_id=self.taxonomy_id)
 
         # check sequence can be translated
         if not self.alphabet._eq(genetic_code.nucleotide_alphabet):
             raise AlphabetMismatch(genetic_code.nucleotide_alphabet, self.alphabet)
         if ntlen % 3 != 0:
             raise ValueError(f"Incomplete sequence of length {len(self)!r}")
+
+        # create copy with metadata
+        protein = DigitalSequence(
+            genetic_code.amino_alphabet,
+            name=self.name,
+            description=self.description,
+            accession=self.accession,
+            source=self.source,
+            taxonomy_id=self.taxonomy_id
+        )
 
         # allocate output buffer
         status = libeasel.sq.esl_sq_GrowTo(protein._sq, aalen)

--- a/pyhmmer/tests/test_easel/test_block.py
+++ b/pyhmmer/tests/test_easel/test_block.py
@@ -272,8 +272,17 @@ class TestDigitalSequenceBlock(_TestSequenceBlock, unittest.TestCase):
     def setUpClass(cls):
         cls.alphabet = Alphabet.dna()
 
-    def _new_sequence(self, name, seq):
-        return TextSequence(name=name, sequence=seq).digitize(self.alphabet)
+    def _new_sequence(self, name, seq,
+                      description=None,
+                      source=None,
+                      taxonomy_id=2):
+
+        return TextSequence(name=name,
+                            sequence=seq,
+                            description=description,
+                            source=source,
+                            taxonomy_id=taxonomy_id
+                            ).digitize(self.alphabet)
 
     def _new_block(self, sequences=()):
         return DigitalSequenceBlock(self.alphabet, sequences)
@@ -291,8 +300,15 @@ class TestDigitalSequenceBlock(_TestSequenceBlock, unittest.TestCase):
         self.assertEqual(tblock[1], seq2.textize())
 
     def test_translate(self):
-        seq1 = self._new_sequence(b"seq1", "ATGCTG")
-        seq2 = self._new_sequence(b"seq1", "ATGCCC")
+        seq1 = self._new_sequence(b"seq1",
+                                  "ATGCTG",
+                                  description=b"one",
+                                  source=b"some_source")
+        seq2 = self._new_sequence(b"seq2",
+                                  "ATGCCC",
+                                  description=b"two",
+                                  source=b"other_source",
+                                  taxonomy_id=2)
 
         block = self._new_block([seq1, seq2])
         prots = block.translate().textize()
@@ -303,7 +319,15 @@ class TestDigitalSequenceBlock(_TestSequenceBlock, unittest.TestCase):
         self.assertEqual(prots[1].sequence, "MP")
         # test names
         self.assertEqual(prots[0].name, b"seq1")
-        self.assertEqual(prots[0].name, b"seq1")
+        self.assertEqual(prots[1].name, b"seq2")
+        # test other metadata fields
+        self.assertEqual(prots[0].description, b"one")
+        self.assertEqual(prots[1].description, b"two")
+        self.assertEqual(prots[0].source, b"some_source")
+        self.assertEqual(prots[1].source, b"other_source")
+        self.assertEqual(prots[0].taxonomy_id, 1)
+        self.assertEqual(prots[1].taxonomy_id, 2)
+
 
     def test_translate_empty(self):
         gencode = GeneticCode()

--- a/pyhmmer/tests/test_easel/test_block.py
+++ b/pyhmmer/tests/test_easel/test_block.py
@@ -5,7 +5,7 @@ from pyhmmer.errors import AlphabetMismatch
 from pyhmmer.easel import (
     Alphabet,
     GeneticCode,
-    SequenceBlock, 
+    SequenceBlock,
     TextSequenceBlock,
     DigitalSequenceBlock,
     Sequence,
@@ -32,7 +32,7 @@ class _TestSequenceBlock(abc.ABC):
 
     def test_identity(self):
         self.assertIsNot(self._new_block(), self._new_block())
-    
+
     def test_len(self):
         seq1 = self._new_sequence(b"seq1", "ATGC")
         seq2 = self._new_sequence(b"seq2", "ATGCA")
@@ -78,7 +78,7 @@ class _TestSequenceBlock(abc.ABC):
         self.assertEqual(len(block), 0)
         block.clear()
         self.assertEqual(len(block), 0)
-        
+
         block = self._new_block()
         self.assertEqual(len(block), 0)
         block.clear()
@@ -100,7 +100,7 @@ class _TestSequenceBlock(abc.ABC):
             block[3]
         with self.assertRaises(IndexError):
             block[-5]
-        
+
     def test_setitem(self):
         seq1 = self._new_sequence(b"seq1", "ATGC")
         seq2 = self._new_sequence(b"seq2", "ATGCA")
@@ -109,7 +109,7 @@ class _TestSequenceBlock(abc.ABC):
         block = self._new_block([seq1, seq2])
         self.assertEqual(len(block), 2)
 
-        block[0] = seq3 
+        block[0] = seq3
         self.assertIs(block[0], seq3)
         self.assertIs(block[1], seq2)
 
@@ -204,7 +204,7 @@ class _TestSequenceBlock(abc.ABC):
         self.assertIn(seq1, block)
         self.assertIn(seq2, block)
         self.assertNotIn(seq3, block)
-        
+
         self.assertNotIn(42, block)
         self.assertNotIn(object(), block)
 
@@ -253,7 +253,7 @@ class TestTextSequenceBlock(_TestSequenceBlock, unittest.TestCase):
 
     def test_digitize(self):
         alphabet = Alphabet.dna()
-        
+
         seq1 = self._new_sequence(b"seq1", "ATGC")
         seq2 = self._new_sequence(b"seq2", "ATGCA")
 
@@ -298,8 +298,12 @@ class TestDigitalSequenceBlock(_TestSequenceBlock, unittest.TestCase):
         prots = block.translate().textize()
 
         self.assertEqual(len(prots), 2)
+        # test sequences
         self.assertEqual(prots[0].sequence, "ML")
         self.assertEqual(prots[1].sequence, "MP")
+        # test names
+        self.assertEqual(prots[0].name, b"seq1")
+        self.assertEqual(prots[0].name, b"seq1")
 
     def test_translate_empty(self):
         gencode = GeneticCode()

--- a/pyhmmer/tests/test_easel/test_block.py
+++ b/pyhmmer/tests/test_easel/test_block.py
@@ -305,14 +305,12 @@ class TestDigitalSequenceBlock(_TestSequenceBlock, unittest.TestCase):
         seq1 = self._new_sequence(b"seq1",
                                   "ATGCTG",
                                   description=b"one",
-                                  source=b"some_source",
-                                  taxonomy_id=1)
+                                  source=b"some_source")
 
         seq2 = self._new_sequence(b"seq2",
                                   "ATGCCC",
                                   description=b"two",
-                                  source=b"other_source",
-                                  taxonomy_id=2)
+                                  source=b"other_source")
 
         block = self._new_block([seq1, seq2])
         prots = block.translate().textize()
@@ -329,8 +327,6 @@ class TestDigitalSequenceBlock(_TestSequenceBlock, unittest.TestCase):
         self.assertEqual(prots[1].description, b"two")
         self.assertEqual(prots[0].source, b"some_source")
         self.assertEqual(prots[1].source, b"other_source")
-        self.assertEqual(prots[1].taxonomy_id, 2)
-        self.assertEqual(prots[0].taxonomy_id, 1)
 
 
 

--- a/pyhmmer/tests/test_easel/test_block.py
+++ b/pyhmmer/tests/test_easel/test_block.py
@@ -272,10 +272,12 @@ class TestDigitalSequenceBlock(_TestSequenceBlock, unittest.TestCase):
     def setUpClass(cls):
         cls.alphabet = Alphabet.dna()
 
-    def _new_sequence(self, name, seq,
+    def _new_sequence(self,
+                      name,
+                      seq,
                       description=None,
                       source=None,
-                      taxonomy_id=2):
+                      taxonomy_id=None):
 
         return TextSequence(name=name,
                             sequence=seq,
@@ -303,7 +305,9 @@ class TestDigitalSequenceBlock(_TestSequenceBlock, unittest.TestCase):
         seq1 = self._new_sequence(b"seq1",
                                   "ATGCTG",
                                   description=b"one",
-                                  source=b"some_source")
+                                  source=b"some_source",
+                                  taxonomy_id=1)
+
         seq2 = self._new_sequence(b"seq2",
                                   "ATGCCC",
                                   description=b"two",
@@ -325,8 +329,9 @@ class TestDigitalSequenceBlock(_TestSequenceBlock, unittest.TestCase):
         self.assertEqual(prots[1].description, b"two")
         self.assertEqual(prots[0].source, b"some_source")
         self.assertEqual(prots[1].source, b"other_source")
-        self.assertEqual(prots[0].taxonomy_id, 1)
         self.assertEqual(prots[1].taxonomy_id, 2)
+        self.assertEqual(prots[0].taxonomy_id, 1)
+
 
 
     def test_translate_empty(self):


### PR DESCRIPTION
- Closes #30 

**Previous behaviour:**
```
with pyhmmer.easel.SequenceFile("COG0012.fna", digital=True) as seqs_file:
    nucleotides = seqs_file.read_block()

print(nucleotides[0].name)
# DigitalSequenceBlock method 
proteins = nucleotides.translate()
print(proteins[0].name)
# DigitalSequence method
print(nucleotides[0].translate().name)
```
```
b'1089456.NCGM2_0913'
b''
b''
```

**Current behaviour:**
```
b'1089456.NCGM2_0913'
b'1089456.NCGM2_0913'
b'1089456.NCGM2_0913'
```