### PR TITLE
Fix iterate hmm

### DIFF
--- a/pyhmmer/plan7.pxd
+++ b/pyhmmer/plan7.pxd
@@ -328,7 +328,7 @@ cdef class Pipeline:
 
     cpdef IterativeSearch iterate_hmm(
         self,
-        DigitalSequence query,
+        HMM query,
         DigitalSequenceBlock sequences,
         Builder builder = ?,
         object select_hits = ?,

--- a/pyhmmer/plan7.pyx
+++ b/pyhmmer/plan7.pyx
@@ -3784,8 +3784,12 @@ cdef class IterativeSearch:
         else:
             hmm, _, _ = self.builder.build_msa(self.msa, self.background)
             n_prev = len(self.msa.sequences)
-            extra_sequences = [self.query]
-            extra_traces = [Trace.from_sequence(self.query)]
+            if isinstance(self.query, HMM):
+                extra_sequences = None
+                extra_traces = None
+            else:
+                extra_sequences = [self.query]
+                extra_traces = [Trace.from_sequence(self.query)]
 
         hits = self._search_hmm(hmm)
         hits.sort(by="key")

--- a/pyhmmer/plan7.pyx
+++ b/pyhmmer/plan7.pyx
@@ -5949,7 +5949,7 @@ cdef class Pipeline:
 
     cpdef IterativeSearch iterate_hmm(
         self,
-        DigitalSequence query,
+        HMM query,
         DigitalSequenceBlock sequences,
         Builder builder = None,
         object select_hits = None,


### PR DESCRIPTION
Fixes #33 

* Changes `query` from DigitalSequence to HMM to be consistent with the intention of the function as well as the documentation
* In the `__next__` method of the iterator, make sure the `extra_sequences` and `extra_traces` are `None` in iterations after the first, when the query is an HMM. Treating it as a sequence breaks the iterator.