### PR TITLE
Seq and profile search fns in wrong doc categories

### DIFF
--- a/docs/api/hmmer/index.rst
+++ b/docs/api/hmmer/index.rst
@@ -17,8 +17,8 @@ Sequence Searches
 
 .. autosummary::
 
-    hmmsearch
-    hmmscan
+    phmmer
+    nhmmer
 
 
 Profile Searches
@@ -32,8 +32,8 @@ Profile Searches
 
 .. autosummary::
 
-    phmmer
-    nhmmer
+    hmmsearch
+    hmmscan
 
 
 Iterative Searches


### PR DESCRIPTION
Just a minor typo in the API docs where the sequence and profile search functions in `pyhmmer.hmmer` are in the wrong categories